### PR TITLE
add missing tsconfig and package

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noResolve": true,
+    "allowUnusedLabels": true,
+    "skipLibCheck": true,
+    "noEmitOnError": true,
+    "strict": false,
+    "removeComments": false,
+    "module": "ESNext",
+    "target": "ESNext",
+    "alwaysStrict": false
+  }
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -224,6 +224,8 @@ const config = {
            * Whether to display the last date the doc was updated.
            */
           showLastUpdateTime: true,
+          // // below remark plugin disabled until we can figure out why it is not transpiling to ESNext properly - swyx
+          // // original PR https://github.com/temporalio/documentation/pull/496/files
           remarkPlugins: [
             [
               () =>
@@ -250,7 +252,6 @@ const config = {
                   tsconfig: path.join(
                     __dirname,
                     "docs",
-                    "typescript",
                     "tsconfig.json"
                   ),
                   externalResolutions: {},

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chart.js": "3.7.1",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.3.3",
+    "readdirp": "^3.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-player": "^2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,7 +7932,7 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdirp@^3.4.0, readdirp@~3.6.0:
+readdirp@^3.4.0, readdirp@^3.6.0, readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==


### PR DESCRIPTION
## What was changed
Adds proper TypeScript configuration so that TS->JS transpilation happens properly in tutorials.

## Why?
The TypeScript that was generated previously was very ugly and hard to follow due to a misconfiguration.

Closes #5 

