### PR TITLE
Resolve issue with unified search not resolving offsite URLs properly.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,6 +188,7 @@ const config = {
     algolia: {
       apiKey: "4a2fa646f476d7756a7cdc599b625bec",
       indexName: "temporal",
+      externalUrlRegex: 'temporal\\.io',
       // contextualSearch: true, // Optional, If you have different version of docs etc (v1 and v2) doesn't display dup results
       appId: "T5D6KNJCQS", // Optional, if you run the DocSearch crawler on your own
       // algoliaOptions: {}, // Optional, if provided by Algolia

--- a/src/pages/changelog.md
+++ b/src/pages/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2022-11-08
+
+* Resolved issue with unified search not resolving offsite URLs properly.
+
 ## 2022-11-02
 
 * Added unified search. Now readers can search both the documentation and learning resources from both the docs and learn sites.


### PR DESCRIPTION

## What was changed
add external url regex pattern

## Why?
Docusaurus was rewriting urls on external links in search results, making them relative to the site root. This prevents that behavior.

