### PR TITLE
activity link changes

### DIFF
--- a/docs/examples/go/background-checks/index.md
+++ b/docs/examples/go/background-checks/index.md
@@ -84,8 +84,8 @@ And the Temporal Platform has built-in Visibility APIs to view the status and ge
 
 This project introduces the following concepts:
 
-- [Activity Definition](https://docs.temporal.io/concepts/what-is-an-activity-definition)
-- [Activity Execution](https://docs.temporal.io/concepts/what-is-an-activity-execution)
+- [Activity Definition](https://docs.temporal.io/activities/#activity-definition)
+- [Activity Execution](https://docs.temporal.io/activities/#activity-execution)
 - [Advanced Visibility](https://docs.temporal.io/concepts/what-is-advanced-visibility)
 - [Child Workflow Execution](https://docs.temporal.io/concepts/what-is-a-child-workflow-execution)
 - [Custom Data Converter](https://docs.temporal.io/concepts/what-is-a-data-converter)


### PR DESCRIPTION
## What was changed
Links have been changed to navigate to proper docs.

## Why?
This is so we don't keep linking to the pages we use to generate our front-facing documentation.

## Checklist
- Change links to technical concepts introduced
- Change links to technical how-tos
- Review other files and change links when necessary

1. Closes TW-143

2. How was this tested:
I changed the links and then ran the site on localhost to test links.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
