### PR TITLE
converting Maven and Gradle in Java Tutorial to Tabs

### DIFF
--- a/docs/getting_started/java/dev_environment/index.md
+++ b/docs/getting_started/java/dev_environment/index.md
@@ -30,7 +30,7 @@ java -version
 
 While you can use any tool you like, such as Gradle or Apache Maven, to build and package your Temporal applications, our tutorials are based on Gradle.
 
-<Tabs groupId="os" queryString>
+<Tabs groupId="build-tool" queryString>
   <TabItem value="maven" label="Maven">
 
 ### Configure Maven


### PR DESCRIPTION
## What was changed
The Gradle and Maven instructions were put behind tabs

## Why?
Better reader experience

Tested manually
https://temporal-learning-bho6gqd2r.preview.thundergun.io/getting_started/java/dev_environment/?os=maven
