### PR TITLE
Add Temporal CLI persistence option for Getting Started tutorials

### DIFF
--- a/docs/getting_started/_temporal_cluster.md
+++ b/docs/getting_started/_temporal_cluster.md
@@ -63,21 +63,12 @@ Once you've installed Temporal CLI and added it to your `PATH`, open a new Termi
 temporal server start-dev
 ```
 
-This command automatically starts the Web UI, creates the default [Namespace](https://docs.temporal.io/namespaces), and uses an in-memory database.
+This command starts a local Temporal Cluster. It starts the Web UI, creates the default [Namespace](https://docs.temporal.io/namespaces), and uses an in-memory database.
 
 * The Temporal Server will be available on `localhost:7233`.
 * The Temporal Web UI will be available at [`http://localhost:8233`](http://localhost:8233/).
 
-Leave the cluster running as you work through tutorials and other projects. You can stop the cluster at any time by pressing `CTRL+C`.
-
-If you used an in-memory database, stopping the server will erase all of your Workflows and all of your Task Queues. If you want to retain those between runs, start the server and specify a database filename:
-
-```command
-temporal server start-dev --db-filename your_temporal.db
-```
-
-When you stop and restart the server and specify the same filename again, your Workflows and other information will be available.
-
+Leave the local Temporal Cluster running as you work through tutorials and other projects. You can stop the Temporal Cluster at any time by pressing `CTRL+C`.
 
 :::tip Change the Web UI port
 
@@ -91,5 +82,10 @@ The Temporal Web UI will now be available at [`http://localhost:8080`](http://lo
 
 :::
 
+The `temporal server start-dev` command uses an in-memory database, so stopping the server will erase all your Workflows and all your Task Queues. If you want to retain those between runs, start the server and specify a database filename using the `--db-filename` option, like this::
 
+```command
+temporal server start-dev --db-filename your_temporal.db
+```
 
+When you stop and restart the Temporal Cluster and specify the same filename again, your Workflows and other information will be available.

--- a/docs/getting_started/go/first_program_in_go/index.md
+++ b/docs/getting_started/go/first_program_in_go/index.md
@@ -341,7 +341,7 @@ Try it out by following these steps:
 2. Switch back to the terminal where your Workflow ran. Start the Workflow again with `go run starter/main.go`.
 3. Verify the Workflow is running in the UI.
 4. Shut down the Temporal Server by either using `CTRL+C` in the terminal window running the server or via the Docker dashboard.
-5. After the Temporal cluster has stopped, restart it. If you are using Temporal CLI, remember to specify the same database file.
+5. After the Temporal cluster has stopped, restart it. If you are using Temporal CLI, run the same command you used previously to ensure you use the same database file.
 
 Visit the UI. Your Workflow is still listed:
 

--- a/docs/getting_started/java/first_program_in_java/index.md
+++ b/docs/getting_started/java/first_program_in_java/index.md
@@ -183,7 +183,7 @@ Unlike many modern applications that require complex leader election processes a
 1. Start the Workflow again.
 2. Verify the Workflow is running in the UI.
 3. Shut down the Temporal server by either using 'Ctrl+C' or via the Docker dashboard.
-5. After the Temporal cluster has stopped, restart it. If you are using Temporal CLI, remember to specify the same database file.
+5. After the Temporal cluster has stopped, restart it. If you are using Temporal CLI, run the same command you used previously to ensure you use the same database file.
 
 Visit the UI. Your Workflow is still listed.
 


### PR DESCRIPTION
Temporal CLI uses an in-memory db. This updates the Dev Environment and Run Your First App tutorials to call out the persistence option.

