### PR TITLE
Simplify background checks deployment.

### DIFF
--- a/docs/examples/go/background-checks/application-deployment.md
+++ b/docs/examples/go/background-checks/application-deployment.md
@@ -14,7 +14,6 @@ The following Docker Images are spun up into a Container stack using [Docker Com
 
 - Temporal Server: Services that facilitate the Temporal Event Loop. The Temporal Server is one half of what makes up a Temporal Cluster.
 - PostgreSQL: Database to persist the state of each Workflow Execution. The Database is the other half of what makes up a Temporal Cluster.
-- Elasticsearch: Database to manage Search Attributes. Optional component of a Temporal Cluster.
 - Temporal Web UI: Browser-based UI that provides Visibility tooling.
 - Grafana: So we can show Dashboards from the metrics.
 - Prometheus: So we can ingest metrics.
@@ -26,7 +25,7 @@ The following Docker Images are spun up into a Container stack using [Docker Com
 - App CLI tools: Process listening for commands that call the application APIs.
 - Dataconverter: Process that runs the Data Converter encryption command.
 
-The project uses existing Docker Images for the Temporal Server, PostgreSQL, Elasticsearch, Grafana, Prometheus, and Mailhog with some minor configuration tweaks.
+The project uses existing Docker Images for the Temporal Server, PostgreSQL, Grafana, Prometheus, and Mailhog with some minor configuration tweaks.
 Everything is wired together using environment variables and hardcoded hostnames.
 The implementation can be viewed in these Docker Compose files:
 

--- a/docs/examples/go/background-checks/application-design-and-implementation.md
+++ b/docs/examples/go/background-checks/application-design-and-implementation.md
@@ -84,7 +84,7 @@ Because the default retention period for a Temporal Cluster is 7 days, this appl
 
 ![Diagram of component topology of the Temporal Application](images/component-topology.svg)
 
-The Temporal Client communicates with the Temporal Cluster (Temporal Server + Database + Elasticsearch).
+The Temporal Client communicates with the Temporal Cluster (Temporal Server + Database).
 
 The Temporal Cluster communicates with the Workers that execute our application code.
 Our application has one Worker Process and one Worker Entity.


### PR DESCRIPTION
We don't need ElasticSearch for search attributes anymore.

https://github.com/temporalio/background-checks/pull/44