### PR TITLE
EDU-1097: Site learn.temporal.io Has Incorrect Meetups Link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,7 +130,7 @@ const config = {
             },
             {
               label: "Meetups",
-              href: "https://lu.ma/temporal",
+              href: "https://temporal.io/community#events",
             },
             {
               label: "Workshops",


### PR DESCRIPTION
## What was changed
The page footer of [https://learn.temporal.io/] has an outdated link for Meetups. We migrated away from [lu.ma](http://lu.ma/) earlier this year. Our home page now uses [https://temporal.io/community#events] as the link target, so the learning sub-site should mirror that.

## Why?
The current link was outdated and no longer functions.

## Checklist
<!--- add/delete as needed --->

This closes EDU-1097.

2. How was this tested:

1. Created the branch in git
2. Edited `docusaurus.config.js`
3. Ran `yarn start` and verified the change in my browser
4. Ran `yarn build`
5. Ran `git commit docusaurus.config.js` after verifying that it was the only relevant change (and that the only modification was the change I made)

Be advised that this is my my first time changing the `docusaurus.config.js` file, so I urge you to make sure that I've done it correctly since the process wasn't documented.

3. Any docs updates needed?
No, although I will make a similar commit for the docs.temporal.io site in a separate PR since the problems exists there too (see EDU-1096)
