### PR TITLE
add explanation for unsafe imports from python 101

### DIFF
--- a/docs/getting_started/python/hello_world_in_python/index.md
+++ b/docs/getting_started/python/hello_world_in_python/index.md
@@ -151,6 +151,14 @@ The method calls the `workflow.execute_activty` method which executes an Activit
 
 Finally, the `run` method returns the result of the Activity Execution.
 
+:::info
+
+In the Temporal Python SDK, Workflow files are reloaded in a sandbox for every run. To keep from reloading an import on every run, you can mark it as pass through so it reuses the module from outside the sandbox. Standard library modules and `temporalio` modules are passed through by default. All other modules that are used in a deterministic way, such as activity function references or third-party modules, should be passed through this way.
+
+This is why this example uses `with workflow.unsafe.imports_passed_through():`. You'll learn more about this later on.
+
+:::
+
 With your Workflow Definition created, you're ready to create the `say_hello` Activity.
 
 ## Create an Activity


### PR DESCRIPTION
Call out the use of unsafe imports in Python using the same explanation from Python 101 to avoid having to get into greater detail here, without confusing new users as to why it's there in the first place.
