### PR TITLE
fix typo on replay 2023 temporal workshops site

### DIFF
--- a/src/pages/replay2023.md
+++ b/src/pages/replay2023.md
@@ -5,7 +5,7 @@ Thanks for attending the Temporal workshops at Replay 2023. You'll find the slid
 ## Temporal 101
 
 - Temporal 101 with Go [code](https://github.com/temporalio/edu-101-go-code) and [slides](/replay2023/temporal-101-with-go-for-replay-2023.pdf)
-- Temporal 101 with TypeScript [code](https://github.com/temporalio/edu-101-typescript-code) [slides](/replay2023/temporal-101-with-typescript-for-replay-2023.pdf)
+- Temporal 101 with TypeScript [code](https://github.com/temporalio/edu-101-typescript-code) and [slides](/replay2023/temporal-101-with-typescript-for-replay-2023.pdf)
 - Temporal 101 with Java [code](https://github.com/temporalio/edu-101-java-code) and [slides](/replay2023/temporal-101-with-java-for-replay-2023.pdf)
 
 These courses are also [available online](https://learn.temporal.io/courses/temporal_101/).


### PR DESCRIPTION
This PR fixes a typo on replay 2023 temporal workshops site so instead of "Temporal 101 with TypeScript code slides", it says"Temporal 101 with TypeScript code and slides"