### PR TITLE
Java Getting Started fixes

### DIFF
--- a/docs/getting_started/java/dev_environment/index.md
+++ b/docs/getting_started/java/dev_environment/index.md
@@ -55,7 +55,7 @@ Add the following dependencies to your Maven Project Object Model (POM) configur
     <dependency>
       <groupId>io.temporal</groupId>
       <artifactId>temporal-sdk</artifactId>
-      <version>1.22.4</version>
+      <version>1.24.1</version>
     </dependency>
 
     <dependency>
@@ -64,7 +64,7 @@ Add the following dependencies to your Maven Project Object Model (POM) configur
       -->
       <groupId>io.temporal</groupId>
       <artifactId>temporal-testing</artifactId>
-      <version>1.22.4</version>
+      <version>1.24.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -81,8 +81,8 @@ Add the following lines to `build.gradle`, your Gradle configuration file. This 
 
 
 ```groovy
-implementation 'io.temporal:temporal-sdk:1.22.4'
-testImplementation 'io.temporal:temporal-testing:1.22.4'
+implementation 'io.temporal:temporal-sdk:1.24.1'
+testImplementation 'io.temporal:temporal-testing:1.24.1'
 ```
 
   </TabItem>

--- a/docs/getting_started/java/first_program_in_java/index.md
+++ b/docs/getting_started/java/first_program_in_java/index.md
@@ -814,15 +814,18 @@ This demo application makes a call to an external service in an Activity. If tha
 To test this out and see how Temporal responds, you'll simulate a bug in the `deposit` Activity method.
 
 
-Let your Workflow continue to run but don't start the Worker yet.
+Try it out by following these steps:
+
+1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
+
+2. Open the `AccountActivityImpl` file and modify the `deposit` method so `activityShouldSucceed` is set to false.
 
 
-1. Open the `AccountActivityImpl` file and modify the `deposit` method so `activityShouldSucceed` is set to false.
+3. Save your changes and switch to the terminal that was running your Worker.
 
+4. Verify the Workflow is running in the [Web UI](http://localhost:8080). If finished, restart it using the Maven command.
 
-2. Save your changes and switch to the terminal that was running your Worker.
-
-3. Start the Worker again:
+5. Start the Worker again:
 
 ```bash
 mvn clean install \

--- a/docs/getting_started/java/first_program_in_java/index.md
+++ b/docs/getting_started/java/first_program_in_java/index.md
@@ -792,7 +792,7 @@ Try it out by following these steps:
 
 
 1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
-2. Verify the Workflow is running in the [Web UI](http://localhost:8080).
+2. Verify the Workflow is running in the [Web UI](http://localhost:8080). If finished, restart it using the Maven command.
 3. Shut down the Temporal Server with `CTRL+C` in the terminal window running the server.
 4. After the Temporal Cluster has stopped, restart it and visit the UI. This can be done by running `temporal server start-dev` in the terminal window and navigating to [localhost:8080](http://localhost:8080/).
 


### PR DESCRIPTION

<!--- For ALL Contributors 👇 -->

## What was changed
1. Fixed non-existent artifact version in POM
2. Added steps to the Simulate Failures examples for additional clarity

## Why?
- Without the first change Maven fails to pull artifact
- Had issues while going through the Simulate Failures examples because of missing clarity/continuity.

## Checklist

1. Closes 
N/R

2. How was this tested:
yarn start followed by visual inspection

3. Any docs updates needed?
No
