### PR TITLE
Fix `gow` to `gow run`

### DIFF
--- a/docs/tutorials/go/background-check/project-setup.mdx
+++ b/docs/tutorials/go/background-check/project-setup.mdx
@@ -515,7 +515,7 @@ Use [`gow`](https://github.com/mitranim/gow) to automatically restart the Worker
 
 ```shell
 go install github.com/mitranim/gow@latest
-gow worker/main.go # automatically restarts when the project files change
+gow run worker/main.go # automatically restarts when the project files change
 ```
 
 :::


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed `gow` to `gow run` in Markdown.

## Why?
The latest `gow` uses `gow run` and will error if you don't have `run`: https://github.com/mitranim/gow?tab=readme-ov-file#usage
