### PR TITLE
EDU-3088: Correct verb "setup" to "set up"

### DIFF
--- a/docs/tutorials/java/background-check/project-setup.mdx
+++ b/docs/tutorials/java/background-check/project-setup.mdx
@@ -1011,7 +1011,7 @@ easily test long-running Workflows in seconds, without having to change your Wor
 You can use the provided testing environments with a Java unit testing framework
 of your choice, such as JUnit. This guide will use JUnit 5.
 
-### Setup testing dependencies
+### Set up testing dependencies
 
 To start using the Java SDK test framework, you need to add [`io.temporal:temporal-testing`](https://search.maven.org/artifact/io.temporal/temporal-testing)
 as a dependency to your project:

--- a/docs/tutorials/typescript/work-queue-slack-app/build/index.mdx
+++ b/docs/tutorials/typescript/work-queue-slack-app/build/index.mdx
@@ -118,7 +118,7 @@ Under Settings in the navigation bar, select **Socket Mode** and toggle ON socke
 
 ![Enable Socket Mode](./images/enable-sockets.png)
 
-Socket Mode means that we don't have to setup and expose a HTTP server to receive events from Slack.
+Socket Mode means that we don't have to set up and expose a HTTP server to receive events from Slack.
 When you enable **Socket Mode**, Slack gives you an application token that you will need when you start the app.
 This token will typically start with `xapp`.
 It is located under **App-Level Tokens** in **Basic Information**.


### PR DESCRIPTION
Two focused point corrections.