### PR TITLE
#311: List more than one example on the Examples page :)

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -11,6 +11,19 @@ image: /img/temporal-logo-twitter-card.png
 
 Explore example applications that use Temporal and gain a clearer understanding of how everything fits together.
 
-[Background Check Application in Go](go/background-checks/index.md)
+# Reference Applications
+Reference Applications are fully documented, end-to-end solutions that show how to use Temporal for a particular use case. If you're new to Temporal, these are a great place to start to understand its capabilities.
 
-More examples coming soon...
+* [Background Check Application in Go](go/background-checks/index.md)
+* [Order Management System in Go](https://github.com/temporalio/reference-app-orders-go)
+
+# Samples
+Samples are more targeted examples that showcase particular features of Temporal and/or support for various language features.
+
+* [Go SDK Samples](https://github.com/temporalio/samples-go)
+* [Java SDK Samples](https://github.com/temporalio/samples-java)
+* [Python SDK Samples](https://github.com/temporalio/samples-python)
+* [TypeScript SDK Samples](https://github.com/temporalio/samples-typescript)
+* [.NET SDK Samples](https://github.com/temporalio/samples-dotnet)
+
+More examples coming soon.


### PR DESCRIPTION
(Corresponding Jira ticket EDU-1842)

## What was changed

This PR adds a few more "non-controversial" examples (meaning, limited to the github.com/temporalio namespace for now) to the [Examples](https://learn.temporal.io/examples/) page, including a reference to the new [Order Management System](https://github.com/temporalio/reference-app-orders-go) which was just launched at Replay, so we can give people a bit more of a head start.

It also introduces the concept of "categories" on this page, so we can expand the list here to other types of examples in the future.

## Why?
See #311 for background/rationale.

## Checklist
<!--- add/delete as needed --->

1. Pushes forward #311 (maybe doesn't "close" it)

2. How was this tested:
I ran `vale index.md` as instructed in the README and proactively fixed a few things that it found. (It unfortunately barfs on the link titles to the SDK examples though :\)

I couldn't seem to get the link checking working (I blame midnight oil :D) so I did a manual click-through on those.

3. Any docs updates needed?
N/A?
