### PR TITLE
EDU-3013: Update links for docusaurus

### DIFF
--- a/docs/getting_started/go/hello_world_in_go/index.md
+++ b/docs/getting_started/go/hello_world_in_go/index.md
@@ -11,7 +11,6 @@ tags:
   - sdk
   - tutorial
 image: /img/temporal-logo-twitter-card.png
-pagination_next: courses/temporal_101/go
 ---
 
 ![Temporal Go SDK](/img/sdk_banners/banner_go.png)

--- a/docs/getting_started/go/run_workers_with_cloud_go/index.md
+++ b/docs/getting_started/go/run_workers_with_cloud_go/index.md
@@ -9,6 +9,7 @@ last_update:
   date: 2024-01-22
 code_repo: https://github.com/temporalio/money-transfer-project-template-go
 image: /img/temporal-logo-twitter-card.png
+pagination_next: courses/temporal_101/go
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting_started/java/hello_world_in_java/index.md
+++ b/docs/getting_started/java/hello_world_in_java/index.md
@@ -12,7 +12,6 @@ tags:
   - sdk
   - tutorial
 image: /img/temporal-logo-twitter-card.png
-pagination_next: courses/temporal_101/java
 code_repo: https://github.com/temporalio/hello-world-project-template-java
 code_notes: branch 'main' has Gradle snipsync source, branch 'maven' has Maven
 ---

--- a/docs/getting_started/java/run_workers_with_cloud_java/index.md
+++ b/docs/getting_started/java/run_workers_with_cloud_java/index.md
@@ -9,6 +9,7 @@ last_update:
   date: 2024-01-22
 code_repo: https://github.com/temporalio/money-transfer-project-template-java
 image: /img/temporal-logo-twitter-card.png
+pagination_next: courses/temporal_101/java
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting_started/python/hello_world_in_python/index.md
+++ b/docs/getting_started/python/hello_world_in_python/index.md
@@ -8,7 +8,6 @@ last_update:
 description: In this tutorial you will build a Temporal Application using the Python SDK. You'll write a Workflow, an Activity, tests, and define a Worker.
 tags: [Python, SDK]
 image: /img/temporal-logo-twitter-card.png
-pagination_next: courses/temporal_101/python
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting_started/python/run_workers_with_cloud_python/index.md
+++ b/docs/getting_started/python/run_workers_with_cloud_python/index.md
@@ -9,6 +9,7 @@ last_update:
   date: 2024-01-22
 code_repo: https://github.com/temporalio/money-transfer-project-template-python
 image: /img/temporal-logo-twitter-card.png
+pagination_next: courses/temporal_101/python
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting_started/typescript/hello_world_in_typescript/index.md
+++ b/docs/getting_started/typescript/hello_world_in_typescript/index.md
@@ -8,7 +8,6 @@ tags: [TypeScript, SDK]
 last_update:
   date: 2022-12-20
 image: /img/temporal-logo-twitter-card.png
-pagination_next: courses/temporal_101/typescript
 ---
 
 ![Temporal TypeScript SDK](/img/sdk_banners/banner_typescript.png)

--- a/docs/getting_started/typescript/run_workers_with_cloud_typescript/index.md
+++ b/docs/getting_started/typescript/run_workers_with_cloud_typescript/index.md
@@ -9,6 +9,7 @@ last_update:
   date: 2024-01-22
 code_repo: https://github.com/temporalio/money-transfer-project-template-ts
 image: /img/temporal-logo-twitter-card.png
+pagination_next: courses/temporal_101/typescript
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
After insertion of Run Workers with Temporal Cloud for X SDK, re-route so hello -> run workers and run workers -> 101 (with full words instead of the default wording)

Update `pagination_next: courses/temporal_101/SDK-NAME` in Docusaurus front matter

To review:

- Confirm hello world's next is workers with cloud.
- Confirm workers with cloud next is 101
- Confirm wording is appropriate for each 
- Confirm links are correct within each SDK