### PR TITLE
Expand Examples to include curated list of SA demos

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,6 +17,23 @@ Reference Applications are fully documented, end-to-end solutions that show how 
 * [Background Check Application in Go](go/background-checks/index.md)
 * [Order Management System in Go](https://github.com/temporalio/reference-app-orders-go)
 
+# Example Applications
+While not intended for production use, Example Applications can nonetheless be useful for seeing Temporal in action for particular use cases and architectural design patterns.
+
+## Use cases
+* **Order Fulfillment** [[TypeScript](https://github.com/temporal-sa/temporal-order-fulfill-demo)] A Temporal workflow for a sample e-commerce order fulfillment use case. This demo showcases Temporal's powerful durability and interactive capabilities. See companion [video](https://www.youtube.com/watch?v=dNVmRfWsNkM).
+* **Money Transfer** [[Java]](https://github.com/temporal-sa/temporal-money-transfer-java) [[TypeScript]](https://github.com/temporal-sa/temporal-money-transfer-typescript) demonstrates core value propositions of Temporal. A custom UI allows users to choose from a number of simulated failure scenarios and use of Temporal primitives such as signals and schedules.
+* **Orchestrate Lambda Functions** [[TypeScript](https://github.com/temporal-sa/temporal-orchestrate-lambda-functions)] A Temporal version of the [AWS Step Functions: Lambda orchestration example](https://docs.aws.amazon.com/step-functions/latest/dg/sample-lambda-orchestration.html) which uses Lambda functions to check a stock price and determine a buy or sell trading recommendation.
+
+## Design Patterns
+* **Entity Workflow Demo** [[Go](https://github.com/temporal-sa/temporal-entity-lifecycle-go)] The purpose of this demo is to illustrate some of the interesting properties of the Entity Lifecycle Pattern (aka Entity Workflows). See companion slide deck on [Long-running workflows](https://docs.google.com/presentation/d/1A2dz4lFiIFz4c_7QlOpahbvesbBY8Y6y65zRrkVgqYE/edit?usp=sharing).
+* **Order Saga Sample** [[Java](https://github.com/temporal-sa/temporal-order-saga)] Demonstrates Temporal's enhanced support for the Saga pattern, supporting recovery from failed transactions. See companion [video](https://www.youtube.com/watch?v=uHDQMfOMFD4).
+
+## Data Encryption
+See the [Temporal Platform Feature Guide](https://docs.temporal.io/production-deployment/data-encryption) for more information on the purpose of Temporal Codec Servers.
+* **Codec Server with JWT Validation** [[TypeScript](https://github.com/temporal-sa/temporal-codec-server)] The codec server uses JSON Web Tokens (JWT) to confirm the authenticity of JWTs issued by Temporal Cloud.
+* **Codec CORS Credentials** [[Go](https://github.com/temporal-sa/codec-cors-credentials)] An implementation of a Temporal [Codec Server](https://docs.temporal.io/dataconversion#codec-server) that supports Cross-Origin Resource Sharing (CORS), and specifically CORS Requests with credentials.
+
 # Samples
 Samples are more targeted examples that showcase particular features of Temporal and/or support for various language features.
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -21,18 +21,18 @@ Reference Applications are fully documented, end-to-end solutions that show how 
 While not intended for production use, Example Applications can nonetheless be useful for seeing Temporal in action for particular use cases and architectural design patterns.
 
 ## Use cases
-* **Order Fulfillment** [[TypeScript](https://github.com/temporal-sa/temporal-order-fulfill-demo)] A Temporal workflow for a sample e-commerce order fulfillment use case. This demo showcases Temporal's powerful durability and interactive capabilities. See companion [video](https://www.youtube.com/watch?v=dNVmRfWsNkM).
+* **Order Fulfillment** [[TypeScript]](https://github.com/temporal-sa/temporal-order-fulfill-demo) A Temporal workflow for a sample e-commerce order fulfillment use case. This demo showcases Temporal's powerful durability and interactive capabilities. See companion [video](https://www.youtube.com/watch?v=dNVmRfWsNkM).
 * **Money Transfer** [[Java]](https://github.com/temporal-sa/temporal-money-transfer-java) [[TypeScript]](https://github.com/temporal-sa/temporal-money-transfer-typescript) demonstrates core value propositions of Temporal. A custom UI allows users to choose from a number of simulated failure scenarios and use of Temporal primitives such as signals and schedules.
-* **Orchestrate Lambda Functions** [[TypeScript](https://github.com/temporal-sa/temporal-orchestrate-lambda-functions)] A Temporal version of the [AWS Step Functions: Lambda orchestration example](https://docs.aws.amazon.com/step-functions/latest/dg/sample-lambda-orchestration.html) which uses Lambda functions to check a stock price and determine a buy or sell trading recommendation.
+* **Orchestrate Lambda Functions** [[TypeScript]](https://github.com/temporal-sa/temporal-orchestrate-lambda-functions) A Temporal version of the [AWS Step Functions: Lambda orchestration example](https://docs.aws.amazon.com/step-functions/latest/dg/sample-lambda-orchestration.html) which uses Lambda functions to check a stock price and determine a buy or sell trading recommendation.
 
 ## Design Patterns
-* **Entity Workflow Demo** [[Go](https://github.com/temporal-sa/temporal-entity-lifecycle-go)] The purpose of this demo is to illustrate some of the interesting properties of the Entity Lifecycle Pattern (aka Entity Workflows). See companion slide deck on [Long-running workflows](https://docs.google.com/presentation/d/1A2dz4lFiIFz4c_7QlOpahbvesbBY8Y6y65zRrkVgqYE/edit?usp=sharing).
-* **Order Saga Sample** [[Java](https://github.com/temporal-sa/temporal-order-saga)] Demonstrates Temporal's enhanced support for the Saga pattern, supporting recovery from failed transactions. See companion [video](https://www.youtube.com/watch?v=uHDQMfOMFD4).
+* **Entity Workflow Demo** [[Go]](https://github.com/temporal-sa/temporal-entity-lifecycle-go) The purpose of this demo is to illustrate some of the interesting properties of the Entity Lifecycle Pattern (aka Entity Workflows). See companion slide deck on [Long-running workflows](https://docs.google.com/presentation/d/1A2dz4lFiIFz4c_7QlOpahbvesbBY8Y6y65zRrkVgqYE/edit?usp=sharing).
+* **Order Saga Sample** [[Java]](https://github.com/temporal-sa/temporal-order-saga) Demonstrates Temporal's enhanced support for the Saga pattern, supporting recovery from failed transactions. See companion [video](https://www.youtube.com/watch?v=uHDQMfOMFD4).
 
 ## Data Encryption
 See the [Temporal Platform Feature Guide](https://docs.temporal.io/production-deployment/data-encryption) for more information on the purpose of Temporal Codec Servers.
-* **Codec Server with JWT Validation** [[TypeScript](https://github.com/temporal-sa/temporal-codec-server)] The codec server uses JSON Web Tokens (JWT) to confirm the authenticity of JWTs issued by Temporal Cloud.
-* **Codec CORS Credentials** [[Go](https://github.com/temporal-sa/codec-cors-credentials)] An implementation of a Temporal [Codec Server](https://docs.temporal.io/dataconversion#codec-server) that supports Cross-Origin Resource Sharing (CORS), and specifically CORS Requests with credentials.
+* **Codec Server with JWT Validation** [[TypeScript]](https://github.com/temporal-sa/temporal-codec-server) The codec server uses JSON Web Tokens (JWT) to confirm the authenticity of JWTs issued by Temporal Cloud.
+* **Codec CORS Credentials** [[Go]](https://github.com/temporal-sa/codec-cors-credentials) An implementation of a Temporal [Codec Server](https://docs.temporal.io/dataconversion#codec-server) that supports Cross-Origin Resource Sharing (CORS), and specifically CORS Requests with credentials.
 
 # Samples
 Samples are more targeted examples that showcase particular features of Temporal and/or support for various language features.


### PR DESCRIPTION
## What was changed
This PR adds a new heading to the [Example Applications](https://learn.temporal.io/examples/) page for... Example Applications. 🤣 These largely come from the https://github.com/temporal-sa/ namespace and show how to do a particular use case or a particular design pattern in Temporal.

What's here represents a "short list" of examples that the SA team has curated that are both a) broadly useful to customers and b) the author has opted in to increased visibility on their code. Because these examples plan to eventually be expanded into multiple languages, we also introduce the idea of indexing by _thing you're solving_ and the programming language it's written in as a secondary consideration.

Big thanks to @steveandroulakis who led the charge here from the SA side.

## Why?
See #311 for the wider rationale for this series of PRs.

## Checklist

1. Closes #311

2. How was this tested:
* Solicited SA team for "short list" of their examples
* Drafted PR in a Google Doc to get the words right
* Checked all of the links for broken ones

3. Any docs updates needed?

Other than this, I don't think so!
