### PR TITLE
Add max attempts back into the Retry Policy

### DIFF
--- a/docs/tutorials/python/trip-booking-app/code/workflows.py
+++ b/docs/tutorials/python/trip-booking-app/code/workflows.py
@@ -55,7 +55,10 @@ class BookingWorkflow:
                 book_hotel,
                 book_input,
                 start_to_close_timeout=timedelta(seconds=10),
-                retry_policy=RetryPolicy(non_retryable_error_types=["ValueError"]),
+                retry_policy=RetryPolicy(
+                    non_retryable_error_types=["ValueError"],
+                    maximum_attempts=book_input.attempts
+                ),
             )
             results["booked_hotel"] = hotel_result
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds max attempts back into the Retry Policy, which had been removed by PR [#309](https://github.com/temporalio/temporal-learning/pull/309).

## Why?
<!-- Tell your future self why have you made these changes -->
The code published prior to today was invalid. It attempted to set the max attempts for an Activity outside the Retry Policy, so the code wouldn't actually even run. PR [#309](https://github.com/temporalio/temporal-learning/pull/309) addressed that through a workaround, which removed the invalid line of code. 

This PR fixes the original problem by moving that code to where it should have originally been.

## Checklist
<!--- add/delete as needed --->

1. Closes EDU-3716

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I ran the example

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No