### PR TITLE
EDU-3853: T102-Go course page shows "null hour" for estimated time

### DIFF
--- a/docs/courses/temporal_102/go.md
+++ b/docs/courses/temporal_102/go.md
@@ -9,7 +9,7 @@ description: "Go beyond the basics and gain a deeper understand of how Temporal 
 custom_edit_url: null
 hide_table_of_contents: true
 last_update:
-  date: 2024-03-28
+  date: 2025-01-29
 image: /img/temporal-logo-twitter-card.png
 ---
 
@@ -18,7 +18,7 @@ image: /img/temporal-logo-twitter-card.png
 
 ![Temporal Go SDK](/img/sdk_banners/banner_go.png)
 
-**Estimated time**: ~⏱️ null hour, self-paced.
+**Estimated time**: ~⏱️ 4 hours, self-paced.
 
 **Cost**: Free
 


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Specified the estimated time for the T102-Go course.

## Why?
<!-- Tell your future self why have you made these changes -->
What was there before was wrong (a null value).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> EDU-3853

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I viewed the preview in Vercel and verified that the null duration was replaced with "4 hours" as I expected.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No