### PR TITLE
fix URLs for python background-check tutorial to point to python chap…

### DIFF
--- a/docs/tutorials/python/background-check/index.mdx
+++ b/docs/tutorials/python/background-check/index.mdx
@@ -21,5 +21,5 @@ In this tutorial, you will build a Background Check application using the Tempor
 The tutorial is laid out in the following chapters:
 
 - [Introduction](/tutorials/python/background-check/introduction.mdx)
-- [Project setup](/tutorials/java/background-check/project-setup.mdx)
-- [Develop for durability](/tutorials/java/background-check/durable-execution.mdx)
+- [Project setup](/tutorials/python/background-check/project-setup.mdx)
+- [Develop for durability](/tutorials/python/background-check/durable-execution.mdx)


### PR DESCRIPTION
…ters, not java ones


## What was changed
Fixed URLs for python background-check tutorial to point to python chapters, not java ones.