### PR TITLE
fix(docs) Remove last line of sample output

### DIFF
--- a/docs/getting_started/typescript/first_program_in_typescript/index.md
+++ b/docs/getting_started/typescript/first_program_in_typescript/index.md
@@ -382,7 +382,6 @@ If this is your first time running this application, TypeScript might download s
 ```output
 Starting transfer from account 85-150 to account 43-812 for $400
 Started Workflow pay-invoice-801 with RunID 67fe2aff-3aa9-4239-af38-9460720832d3
-Transfer complete (transaction IDs: W9860038178, D8057327891)
 ```
 
 The Workflow is now running. Leave the program running.


### PR DESCRIPTION
## What was changed
Removed `Transfer complete (transaction IDs: W9860038178, D8057327891)` from the sample output in the "Start Workflow" section of the "Run your first Temporal application with the TypeScript SDK" tutorial

## Why?
At this point in the tutorial, only the Workflow has been started (starting the Worker happens later).

The output of `npm run client` will only have the first two lines as the Workflow hasn't executed yet (no Workers)

## Checklist
**How was this tested:** Started docs site locally and checked tutorial page looked correct
