### PR TITLE
docs: fix wrong filename issue

### DIFF
--- a/docs/getting_started/python/hello_world_in_python/index.md
+++ b/docs/getting_started/python/hello_world_in_python/index.md
@@ -45,9 +45,7 @@ All the code in this tutorial is available in the [hello-world python template](
 
 ## Prerequisites
 
-Before starting this tutorial:
-
-- [Set up a local development environment for Temporal and Python](../dev_environment/index.md).
+- Ensure you have a running local Temporal server. For more information, refer to[Set up a local development environment for Temporal and Python](../dev_environment/index.md).
 
 ## ![](/img/icons/harbor-crane.png) Create a new Python project
 
@@ -225,10 +223,10 @@ Create an empty `__init__.py` file within that directory:
 touch tests/__init__.py
 ```
 
-Create the `test_run_workflow.py` file in the `tests` directory and add the following content to test the Workflow:
+Create the `/test_run_worker.py` file in the `tests` directory and add the following content to test the Workflow:
 
 ```command
-touch tests/test_run_workflow.py
+touch tests/test_run_worker.py
 ```
 
 <!--SNIPSTART hello-world-project-template-python-tests {"selectedLines": ["1-28"]} -->
@@ -439,7 +437,11 @@ You have a Workflow, an Activity, a Worker, and a way to start a Workflow Execut
 
 To run your Temporal Application, you need to start the Workflow and the Worker. You can start these in any order, but you'll need to run each command from a separate terminal window, as the Worker needs to be constantly running to look for tasks to execute.
 
-First, ensure that your local Temporal Cluster is running.
+First, ensure that your local Temporal Cluster is running. If it is not running, run the following command to start it.
+
+```
+temporal server start-dev
+```
 
 To start the Worker, run this command from the project root:
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Changed the wrong filename reference in the unit test section
- Added a command to run the temporal server. I know we already list it in the prerequisite, but i think many learners tear down the server between the pages and forget to have it running. I myself ran into this issue as well. 

## Why?
<!-- Tell your future self why have you made these changes -->
- Reduce confusion for new learners with consistent filenames and more handholding

