### PR TITLE
Spelling correction in infrastructure documentation

### DIFF
--- a/docs/tutorials/infrastructure/configuring-sqlite-binary/index.md
+++ b/docs/tutorials/infrastructure/configuring-sqlite-binary/index.md
@@ -294,7 +294,7 @@ Both services should now be running in the background. Navigate to **YOUR_SERVER
 
 ### Other Database Backends
 
-This tutorial provides an example of using Temporal with a SQLite database backend. Temporal also supports MySQL, PostgreSQL, and Cassandra as database backends. Refer to the [datasores](https://docs.temporal.io/references/configuration#datastores) documentation reference to make changes.
+This tutorial provides an example of using Temporal with a SQLite database backend. Temporal also supports MySQL, PostgreSQL, and Cassandra as database backends. Refer to the [datastores](https://docs.temporal.io/references/configuration#datastores) documentation reference to make changes.
 
 ### Load Balancing
 


### PR DESCRIPTION

## What was changed
spelling mistake in url display name: datasores -> datastores


## Why?
Noticed it when reading documentation so might as well fix it
