### PR TITLE
Changed capitalization of two words to reflect our standard

### DIFF
--- a/docs/getting_started/java/hello_world_in_java/index.md
+++ b/docs/getting_started/java/hello_world_in_java/index.md
@@ -540,7 +540,7 @@ public interface Shared {
 
 Now you'll create the Worker process. In this tutorial you'll create a small standalone Worker program so you can see how all of the components work together. 
 
-Create the file `HelloWorldWorker.java` in `app/src/main/java/helloworldapp` and add the following code to connect to the Temporal Server, instantiate the Worker, and register the workflow and activities:
+Create the file `HelloWorldWorker.java` in `app/src/main/java/helloworldapp` and add the following code to connect to the Temporal Server, instantiate the Worker, and register the Workflow and Activities:
 
 <!--SNIPSTART hello-world-project-template-java-worker-->
 [app/src/main/java/helloworldapp/HelloWorldWorker.java](https://github.com/temporalio/hello-world-project-template-java/blob/main/app/src/main/java/helloworldapp/HelloWorldWorker.java)


### PR DESCRIPTION
This PR corrects the capitalization of two words. The main goal, however, is to ensure that a Vercel deployment gets created, which failed to happen a few minutes ago due to an authorization error that occurred while I was merging a community-contributed PR for this same section. In other words, this is a trivial (though beneficial) change that I am making so I can verify that the auth problem is fixed now.