### PR TITLE
Add Amplitude tracking for educational sign-up CTAs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -331,6 +331,11 @@ const config = {
       defer: true,
     },
     {
+      src: "/scripts/amplitude-cta-tracking.js",
+      async: true,
+      defer: true,
+    },
+    {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
       "data-website-id": "13e12f4a-b295-4cb5-9470-783dc6b98f68",
       "data-project-name": "Temporal",

--- a/static/scripts/amplitude-cta-tracking.js
+++ b/static/scripts/amplitude-cta-tracking.js
@@ -1,0 +1,48 @@
+(function () {
+  // Tracks clicks on the "sign up for educational content" CTAs that appear across
+  // the tutorials (e.g. the Nexus sync Java tutorial) and reports them to Amplitude.
+  //
+  // Implementation notes:
+  // - Uses event delegation on `document`, so it survives Docusaurus client-side
+  //   navigation and automatically covers every current and future page that
+  //   contains the CTA -- no per-page wiring required.
+  // - Targets the CTAs by their destination URL, so it catches both the inline
+  //   ":::tip" CTA and the end-of-page CTA without needing custom CSS classes.
+  //
+  // The Amplitude Browser SDK is loaded site-wide via Google Tag Manager (the
+  // `amplitude` global is already present at runtime), so no SDK loader or API
+  // key is needed here. Every track call is still guarded, so this safely no-ops
+  // if the `amplitude` global is ever unavailable.
+  var CTA_URL_FRAGMENT = "pages.temporal.io/get-updates-education";
+
+  document.addEventListener(
+    "click",
+    function (event) {
+      var target = event.target;
+      if (!target || typeof target.closest !== "function") return;
+
+      var link = target.closest('a[href*="' + CTA_URL_FRAGMENT + '"]');
+      if (!link) return;
+
+      if (
+        typeof window.amplitude === "undefined" ||
+        !window.amplitude ||
+        typeof window.amplitude.track !== "function"
+      ) {
+        return;
+      }
+
+      // The inline CTA lives inside a Docusaurus admonition (the ":::tip" box);
+      // the end-of-page "What's Next" CTA is a plain paragraph.
+      var ctaLocation = link.closest(".theme-admonition") ? "inline" : "bottom";
+
+      window.amplitude.track("CTA Clicked", {
+        cta_text: (link.textContent || "").trim(),
+        page_path: window.location.pathname,
+        cta_destination: link.href,
+        cta_location: ctaLocation,
+      });
+    },
+    true
+  );
+})();


### PR DESCRIPTION
## What

Adds Amplitude tracking for the **"Sign up here to get notified when we drop new educational content"** CTAs in the tutorials.

A single site-wide script (`static/scripts/amplitude-cta-tracking.js`, registered in `docusaurus.config.js`) uses **event delegation on the CTA destination URL** (`pages.temporal.io/get-updates-education`), so it:

- Covers **both CTAs** on a page — the inline `:::tip` CTA and the end-of-page "What's Next" CTA
- Automatically covers the **same CTA on all 8+ tutorial pages**, with no per-page wiring
- **Survives Docusaurus client-side navigation** (a plain `addEventListener` on load would not)
- Differentiates `cta_location`: `"inline"` (inside a `.theme-admonition` tip box) vs `"bottom"`

### Event payload

Fires a `CTA Clicked` event:

```js
{
  cta_text: "Sign up here",        // actual link text
  page_path: window.location.pathname,
  cta_destination: "https://pages.temporal.io/get-updates-education",
  cta_location: "inline"           // or "bottom"
}
```

### Notes

- The `amplitude` global is already loaded site-wide via **Google Tag Manager**, so no SDK loader or API key is needed in this repo. Every `track` call is still guarded to safely no-op if `amplitude` is ever unavailable.

## Verification

Tested locally against the Nexus sync Java tutorial. Confirmed by Amplitude:

> The network request in your screenshot shows:
> - URL: `https://api2.amplitude.com/2/httpapi` ✅
> - Status Code: green, successful response ✅
> - Origin: `http://localhost:3000` ✅
>
> The data is reaching Amplitude. It just takes a little time (usually 5–15 minutes) for brand new events to appear in the taxonomy — and the taxonomy check just now still shows nothing yet, so it's still processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)