### PR TITLE
first program in python fix

### DIFF
--- a/docs/getting_started/python/first_program_in_python/index.md
+++ b/docs/getting_started/python/first_program_in_python/index.md
@@ -121,7 +121,6 @@ class MoneyTransfer:
     @workflow.run
     async def run(self, payment_details: PaymentDetails) -> str:
         retry_policy = RetryPolicy(
-            maximum_attempts=3,
             maximum_interval=timedelta(seconds=2),
             non_retryable_error_types=["InvalidAccountError", "InsufficientFundsError"],
         )
@@ -159,10 +158,12 @@ class MoneyTransfer:
                 workflow.logger.info(
                     f"Refund successful. Confirmation ID: {refund_output}"
                 )
-                raise deposit_err
             except ActivityError as refund_error:
                 workflow.logger.error(f"Refund failed: {refund_error}")
-                raise refund_error
+                raise refund_error from deposit_err
+
+            # Re-raise deposit error if refund was successful
+            raise deposit_err
 
 
 ```


### PR DESCRIPTION
In the Python first-program tutorial, the full workflows.py code sample near the top of the page was out of sync with the actual template repo.

Specifically, the snippet still showed:
- maximum_attempts=3 in the RetryPolicy — the repo no longer sets maximum_attempts at all 
- An outdated deposit/refund error-handling block (raise deposit_err misplaced inside the try, and raise refund_error without exception chaining).
