### PR TITLE
clarify stopping worker statement

### DIFF
--- a/docs/getting_started/dotnet/first_program_in_dotnet/index.md
+++ b/docs/getting_started/dotnet/first_program_in_dotnet/index.md
@@ -629,7 +629,7 @@ Unlike many modern applications that require complex processes and external data
 Try it out by following these steps:
 
 
-1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish.
 2. Switch back to the terminal where your Workflow ran. Start the Workflow again with `dotnet run --project MoneyTransferClient`.
 3. Verify the Workflow is running in the [Web UI](http://localhost:8233).
 4. Shut down the Temporal Server by either using `CTRL+C` in the terminal window running the server.

--- a/docs/getting_started/go/first_program_in_go/index.md
+++ b/docs/getting_started/go/first_program_in_go/index.md
@@ -529,7 +529,7 @@ Unlike many modern applications that require complex leader election processes a
 
 Try it out by following these steps:
 
-1. Make sure your Worker is stopped before proceeding so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. 
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish. 
 2. Switch back to the terminal where your Workflow ran. Start the Workflow again with `go run start/main.go`.
 3. Verify the Workflow is running in the UI.
 4. Shut down the Temporal Server by either using `CTRL+C` in the terminal window running the server or via the Docker dashboard.

--- a/docs/getting_started/java/first_program_in_java/index.md
+++ b/docs/getting_started/java/first_program_in_java/index.md
@@ -791,7 +791,7 @@ Unlike many modern applications that require complex processes and external data
 Try it out by following these steps:
 
 
-1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish.
 2. Verify the Workflow is running in the [Web UI](http://localhost:8080). If finished, restart it using the Maven command.
 3. Shut down the Temporal Server with `CTRL+C` in the terminal window running the server.
 4. After the Temporal Cluster has stopped, restart it and visit the UI. This can be done by running `temporal server start-dev` in the terminal window and navigating to [localhost:8080](http://localhost:8080/).
@@ -816,7 +816,7 @@ To test this out and see how Temporal responds, you'll simulate a bug in the `de
 
 Try it out by following these steps:
 
-1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish.
 
 2. Open the `AccountActivityImpl` file and modify the `deposit` method so `activityShouldSucceed` is set to false.
 

--- a/docs/getting_started/python/first_program_in_python/index.md
+++ b/docs/getting_started/python/first_program_in_python/index.md
@@ -493,7 +493,7 @@ Unlike many modern applications that require complex processes and external data
 
 Try it out by following these steps:
 
-1. Make sure your Worker is stopped before proceeding, so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`.
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish.
 2. Switch back to the terminal where your Workflow ran. Start the Workflow again with `python run_workflow.py`.
 3. Verify the Workflow is running in the UI.
 4. Shut down the Temporal Server by either using `CTRL+C` in the terminal window running the server.

--- a/docs/getting_started/typescript/first_program_in_typescript/index.md
+++ b/docs/getting_started/typescript/first_program_in_typescript/index.md
@@ -513,7 +513,7 @@ Unlike many modern applications that require complex leader election processes a
 
 Try it out by following these steps:
 
-1. Make sure your Worker is stopped before proceeding so your Workflow doesn't finish. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. 
+1. Switch to the terminal that's running your Worker and stop it by pressing `CTRL+C`. Stopping the Worker before you proceed ensures your Workflow doesn't finish. 
 2. Switch back to the terminal where your Workflow ran. Start the Workflow again with `npm run client`.
 3. Verify the Workflow is running in the UI.
 4. Shut down the Temporal Server by either using `CTRL+C` in the terminal window running the server or via the Docker dashboard.


### PR DESCRIPTION
Fix contradictory Worker-stop instruction in getting started guides

The "Simulate failures" step told readers to "make sure your Worker is stopped before proceeding" and then to "stop it by pressing CTRL+C" in the same sentence — contradictory, since the Worker is actually running at that point. Reworded to a single clear instruction.

Applied across all five language guides (Go, Python, TypeScript, Java, .NET).